### PR TITLE
Update atomic_float dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ keywords = ["embedded-hal"]
 
 [dependencies]
 embedded-can = "0.4.1"
-atomic_float = { version = "0.1.0", default-features = false }
+atomic_float = { git = "https://github.com/JanekGraff/atomic_float.git", branch = "operation-guards", default-features = false }


### PR DESCRIPTION
Use a fork of atomic_float that contains fixes for the build process for targets that do not support all atomic operations